### PR TITLE
Add portfolio history tracking with daily snapshots and charts

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -8,7 +8,7 @@ from sqlalchemy import inspect, text
 
 from .database import Base, engine
 from .questrade_auth import exchange_token, _read_token
-from .routers import portfolios, holdings, targets, questrade, accounts, sync
+from .routers import portfolios, holdings, targets, questrade, accounts, sync, snapshots
 
 load_dotenv()
 
@@ -178,3 +178,4 @@ app.include_router(targets.router)
 app.include_router(questrade.router)
 app.include_router(accounts.router)
 app.include_router(sync.router)
+app.include_router(snapshots.router)

--- a/backend/models.py
+++ b/backend/models.py
@@ -1,6 +1,6 @@
-from datetime import datetime, timezone
+from datetime import datetime, date, timezone
 
-from sqlalchemy import ForeignKey, Text, Float, Integer
+from sqlalchemy import ForeignKey, Text, Float, Integer, Date, Index, UniqueConstraint
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from .database import Base
@@ -84,3 +84,65 @@ class AllocationTarget(Base):
     dimension: Mapped[str] = mapped_column(Text, nullable=False, default="asset_type")  # "asset_type" | "sector" | "geography"
 
     portfolio: Mapped["Portfolio"] = relationship(back_populates="targets")
+
+
+class PortfolioSnapshot(Base):
+    __tablename__ = "portfolio_snapshots"
+    __table_args__ = (
+        UniqueConstraint("portfolio_id", "snapshot_date"),
+    )
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    portfolio_id: Mapped[int] = mapped_column(ForeignKey("portfolios.id", ondelete="CASCADE"), nullable=False)
+    snapshot_date: Mapped[date] = mapped_column(Date, nullable=False)
+    total_value_base: Mapped[float] = mapped_column(Float, nullable=False)
+    cash_value_base: Mapped[float] = mapped_column(Float, nullable=False)
+    eur_to_base: Mapped[float] = mapped_column(Float, nullable=False)
+    usd_to_base: Mapped[float] = mapped_column(Float, nullable=False)
+    created_at: Mapped[datetime] = mapped_column(default=_utcnow)
+
+    allocations: Mapped[list["SnapshotAllocation"]] = relationship(
+        back_populates="snapshot", cascade="all, delete-orphan"
+    )
+    holdings: Mapped[list["SnapshotHolding"]] = relationship(
+        back_populates="snapshot", cascade="all, delete-orphan"
+    )
+
+
+class SnapshotAllocation(Base):
+    __tablename__ = "snapshot_allocations"
+    __table_args__ = (
+        Index("ix_snapshot_allocations_snapshot_dimension", "snapshot_id", "dimension"),
+    )
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    snapshot_id: Mapped[int] = mapped_column(ForeignKey("portfolio_snapshots.id", ondelete="CASCADE"), nullable=False)
+    dimension: Mapped[str] = mapped_column(Text, nullable=False)
+    category: Mapped[str] = mapped_column(Text, nullable=False)
+    value_base: Mapped[float] = mapped_column(Float, nullable=False)
+    pct: Mapped[float] = mapped_column(Float, nullable=False)
+
+    snapshot: Mapped["PortfolioSnapshot"] = relationship(back_populates="allocations")
+
+
+class SnapshotHolding(Base):
+    __tablename__ = "snapshot_holdings"
+    __table_args__ = (
+        Index("ix_snapshot_holdings_snapshot_id", "snapshot_id"),
+        Index("ix_snapshot_holdings_holding_id", "holding_id"),
+    )
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    snapshot_id: Mapped[int] = mapped_column(ForeignKey("portfolio_snapshots.id", ondelete="CASCADE"), nullable=False)
+    holding_id: Mapped[int | None] = mapped_column(ForeignKey("holdings.id", ondelete="SET NULL"))
+    account_id: Mapped[int | None] = mapped_column(ForeignKey("accounts.id", ondelete="SET NULL"))
+    name: Mapped[str] = mapped_column(Text, nullable=False)
+    ticker: Mapped[str | None] = mapped_column(Text)
+    asset_type: Mapped[str] = mapped_column(Text, nullable=False)
+    quantity: Mapped[float] = mapped_column(Float, nullable=False)
+    price_per_unit: Mapped[float] = mapped_column(Float, nullable=False)
+    currency: Mapped[str] = mapped_column(Text, nullable=False)
+    value_base: Mapped[float] = mapped_column(Float, nullable=False)
+    price_date: Mapped[date | None] = mapped_column(Date)
+
+    snapshot: Mapped["PortfolioSnapshot"] = relationship(back_populates="holdings")

--- a/backend/routers/snapshots.py
+++ b/backend/routers/snapshots.py
@@ -1,0 +1,215 @@
+"""Portfolio snapshot endpoints."""
+
+from datetime import date, datetime
+
+from fastapi import APIRouter, Depends, HTTPException, Query
+from sqlalchemy.orm import Session
+
+from ..database import get_db
+from ..models import Portfolio, PortfolioSnapshot, SnapshotAllocation, SnapshotHolding
+from ..schemas import (
+    SnapshotSummary,
+    PortfolioHistoryPoint,
+    PortfolioHistoryResponse,
+    AllocationHistoryPoint,
+    AllocationHistoryResponse,
+    HoldingHistoryPoint,
+    HoldingHistoryResponse,
+)
+from ..services.snapshots import create_snapshot
+
+router = APIRouter(prefix="/api/snapshots", tags=["snapshots"])
+
+
+@router.post("/{portfolio_id}", response_model=SnapshotSummary)
+def take_snapshot(portfolio_id: int, db: Session = Depends(get_db)):
+    """Manually create a snapshot for today."""
+    portfolio = db.get(Portfolio, portfolio_id)
+    if not portfolio:
+        raise HTTPException(404, "Portfolio not found")
+
+    snapshot = create_snapshot(db, portfolio_id)
+    return snapshot
+
+
+@router.get("/{portfolio_id}", response_model=list[SnapshotSummary])
+def list_snapshots(
+    portfolio_id: int,
+    limit: int = Query(30, ge=1, le=365),
+    db: Session = Depends(get_db),
+):
+    """List recent snapshots for a portfolio."""
+    portfolio = db.get(Portfolio, portfolio_id)
+    if not portfolio:
+        raise HTTPException(404, "Portfolio not found")
+
+    rows = (
+        db.query(PortfolioSnapshot)
+        .filter_by(portfolio_id=portfolio_id)
+        .order_by(PortfolioSnapshot.snapshot_date.desc())
+        .limit(limit)
+        .all()
+    )
+    return rows
+
+
+@router.get("/{portfolio_id}/history", response_model=PortfolioHistoryResponse)
+def portfolio_history(
+    portfolio_id: int,
+    from_date: date | None = Query(None, alias="from"),
+    to_date: date | None = Query(None, alias="to"),
+    db: Session = Depends(get_db),
+):
+    """Portfolio value over time."""
+    portfolio = db.get(Portfolio, portfolio_id)
+    if not portfolio:
+        raise HTTPException(404, "Portfolio not found")
+
+    q = db.query(PortfolioSnapshot).filter_by(portfolio_id=portfolio_id)
+    if from_date:
+        q = q.filter(PortfolioSnapshot.snapshot_date >= from_date)
+    if to_date:
+        q = q.filter(PortfolioSnapshot.snapshot_date <= to_date)
+    rows = q.order_by(PortfolioSnapshot.snapshot_date.asc()).all()
+
+    return PortfolioHistoryResponse(
+        base_currency=portfolio.base_currency,
+        data_points=[
+            PortfolioHistoryPoint(
+                date=s.snapshot_date,
+                total_value_base=s.total_value_base,
+                cash_value_base=s.cash_value_base,
+            )
+            for s in rows
+        ],
+    )
+
+
+@router.get("/{portfolio_id}/allocations", response_model=AllocationHistoryResponse)
+def allocation_history(
+    portfolio_id: int,
+    dimension: str = Query("asset_type"),
+    from_date: date | None = Query(None, alias="from"),
+    to_date: date | None = Query(None, alias="to"),
+    db: Session = Depends(get_db),
+):
+    """Allocation percentages over time for a dimension."""
+    portfolio = db.get(Portfolio, portfolio_id)
+    if not portfolio:
+        raise HTTPException(404, "Portfolio not found")
+
+    q = db.query(PortfolioSnapshot).filter_by(portfolio_id=portfolio_id)
+    if from_date:
+        q = q.filter(PortfolioSnapshot.snapshot_date >= from_date)
+    if to_date:
+        q = q.filter(PortfolioSnapshot.snapshot_date <= to_date)
+    snapshot_rows = q.order_by(PortfolioSnapshot.snapshot_date.asc()).all()
+
+    snapshot_ids = [s.id for s in snapshot_rows]
+    allocations = (
+        db.query(SnapshotAllocation)
+        .filter(
+            SnapshotAllocation.snapshot_id.in_(snapshot_ids),
+            SnapshotAllocation.dimension == dimension,
+        )
+        .all()
+    )
+
+    # Group by snapshot_id
+    alloc_by_snapshot: dict[int, dict[str, float]] = {}
+    all_categories: set[str] = set()
+    for a in allocations:
+        alloc_by_snapshot.setdefault(a.snapshot_id, {})[a.category] = a.pct
+        all_categories.add(a.category)
+
+    categories = sorted(all_categories)
+    data_points = []
+    for s in snapshot_rows:
+        values = alloc_by_snapshot.get(s.id, {})
+        data_points.append(AllocationHistoryPoint(
+            date=s.snapshot_date,
+            values={cat: values.get(cat, 0.0) for cat in categories},
+        ))
+
+    return AllocationHistoryResponse(
+        dimension=dimension,
+        categories=categories,
+        data_points=data_points,
+    )
+
+
+@router.get("/{portfolio_id}/holdings/{holding_id}", response_model=HoldingHistoryResponse)
+def holding_history(
+    portfolio_id: int,
+    holding_id: int,
+    from_date: date | None = Query(None, alias="from"),
+    to_date: date | None = Query(None, alias="to"),
+    db: Session = Depends(get_db),
+):
+    """Single holding value over time."""
+    portfolio = db.get(Portfolio, portfolio_id)
+    if not portfolio:
+        raise HTTPException(404, "Portfolio not found")
+
+    q = db.query(PortfolioSnapshot).filter_by(portfolio_id=portfolio_id)
+    if from_date:
+        q = q.filter(PortfolioSnapshot.snapshot_date >= from_date)
+    if to_date:
+        q = q.filter(PortfolioSnapshot.snapshot_date <= to_date)
+    snapshot_rows = q.order_by(PortfolioSnapshot.snapshot_date.asc()).all()
+
+    snapshot_ids = [s.id for s in snapshot_rows]
+    holding_snaps = (
+        db.query(SnapshotHolding)
+        .filter(
+            SnapshotHolding.snapshot_id.in_(snapshot_ids),
+            SnapshotHolding.holding_id == holding_id,
+        )
+        .all()
+    )
+
+    # Build lookup
+    snap_date_map = {s.id: s.snapshot_date for s in snapshot_rows}
+    holding_name = ""
+    ticker = None
+    data_points = []
+    for hs in holding_snaps:
+        holding_name = hs.name
+        ticker = hs.ticker
+        data_points.append(HoldingHistoryPoint(
+            date=snap_date_map[hs.snapshot_id],
+            quantity=hs.quantity,
+            price_per_unit=hs.price_per_unit,
+            value_base=hs.value_base,
+        ))
+
+    data_points.sort(key=lambda p: p.date)
+
+    return HoldingHistoryResponse(
+        holding_name=holding_name,
+        ticker=ticker,
+        data_points=data_points,
+    )
+
+
+@router.delete("/{portfolio_id}/history")
+def delete_history(
+    portfolio_id: int,
+    before: date = Query(...),
+    db: Session = Depends(get_db),
+):
+    """Delete snapshots before a given date for manual cleanup."""
+    portfolio = db.get(Portfolio, portfolio_id)
+    if not portfolio:
+        raise HTTPException(404, "Portfolio not found")
+
+    deleted = (
+        db.query(PortfolioSnapshot)
+        .filter(
+            PortfolioSnapshot.portfolio_id == portfolio_id,
+            PortfolioSnapshot.snapshot_date < before,
+        )
+        .delete()
+    )
+    db.commit()
+    return {"deleted": deleted}

--- a/backend/routers/sync.py
+++ b/backend/routers/sync.py
@@ -13,6 +13,7 @@ from ..schemas import (
 )
 from ..services.price_sync import fetch_prices
 from ..services.exchange_rates import fetch_ecb_rates, compute_rates_for_base
+from ..services.snapshots import create_snapshot
 
 router = APIRouter(prefix="/api/sync", tags=["sync"])
 
@@ -79,6 +80,7 @@ def sync_prices(
                     old_price=old_price,
                     new_price=data["price"],
                     currency=data["currency"],
+                    price_date=data.get("price_date"),
                 )
             )
         else:
@@ -88,6 +90,13 @@ def sync_prices(
             errors.append(f"Failed to fetch price for {yf_name}")
 
     db.commit()
+
+    # Auto-create snapshot after successful price sync
+    try:
+        create_snapshot(db, portfolio_id)
+    except Exception:
+        pass  # Snapshot failure shouldn't break price sync
+
     failed = len(syncable) - updated
     return PriceSyncResult(
         updated=updated, failed=failed, details=details, errors=errors

--- a/backend/schemas.py
+++ b/backend/schemas.py
@@ -1,5 +1,5 @@
 import json
-from datetime import datetime
+from datetime import datetime, date
 from pydantic import BaseModel, field_validator, model_validator
 
 from .services.price_sync import VALID_EXCHANGES
@@ -148,6 +148,7 @@ class PriceSyncDetail(BaseModel):
     old_price: float
     new_price: float
     currency: str
+    price_date: date | None = None
 
 
 class PriceSyncResult(BaseModel):
@@ -231,3 +232,49 @@ class RebalanceResult(BaseModel):
     total_value: float
     base_currency: str
     suggestions: list[RebalanceSuggestion]
+
+
+# ── Snapshots ────────────────────────────────────────────
+
+class SnapshotSummary(BaseModel):
+    id: int
+    snapshot_date: date
+    total_value_base: float
+    created_at: datetime
+
+    model_config = {"from_attributes": True}
+
+
+class PortfolioHistoryPoint(BaseModel):
+    date: date
+    total_value_base: float
+    cash_value_base: float
+
+
+class PortfolioHistoryResponse(BaseModel):
+    base_currency: str
+    data_points: list[PortfolioHistoryPoint]
+
+
+class AllocationHistoryPoint(BaseModel):
+    date: date
+    values: dict[str, float]
+
+
+class AllocationHistoryResponse(BaseModel):
+    dimension: str
+    categories: list[str]
+    data_points: list[AllocationHistoryPoint]
+
+
+class HoldingHistoryPoint(BaseModel):
+    date: date
+    quantity: float
+    price_per_unit: float
+    value_base: float
+
+
+class HoldingHistoryResponse(BaseModel):
+    holding_name: str
+    ticker: str | None
+    data_points: list[HoldingHistoryPoint]

--- a/backend/services/exchange_rates.py
+++ b/backend/services/exchange_rates.py
@@ -7,7 +7,7 @@ import xml.etree.ElementTree as ET
 import httpx
 
 ECB_DAILY_URL = "https://www.ecb.europa.eu/stats/eurofxref/eurofxref-daily.xml"
-ECB_NS = {"gesmes": "http://www.gesmes.org/xml/2002-08-01", "ecb": "http://www.ecb.int/vocabulary/2002-08-01/euref"}
+ECB_NS = {"gesmes": "http://www.gesmes.org/xml/2002-08-01", "ecb": "http://www.ecb.int/vocabulary/2002-08-01/eurofxref"}
 
 
 def fetch_ecb_rates() -> tuple[dict[str, float], str]:

--- a/backend/services/price_sync.py
+++ b/backend/services/price_sync.py
@@ -88,8 +88,8 @@ def fetch_prices(
         holdings: List of dicts with keys: id, ticker, exchange, asset_type
 
     Returns:
-        {holding_id: {"price": float, "currency": str}} for each
-        successfully fetched holding.
+        {holding_id: {"price": float, "currency": str, "price_date": date}}
+        for each successfully fetched holding.
     """
     if not holdings:
         return {}
@@ -110,14 +110,19 @@ def fetch_prices(
 
     for yf_ticker in yf_tickers:
         try:
-            info = tickers_obj.tickers[yf_ticker].fast_info
-            price = float(info.last_price)
-            currency = str(info.currency).upper()
+            ticker_obj = tickers_obj.tickers[yf_ticker]
+            hist = ticker_obj.history(period="5d")
+            if hist.empty:
+                continue
+            price = float(hist["Close"].iloc[-1])
+            price_date = hist.index[-1].date()
+            currency = str(ticker_obj.fast_info.currency).upper()
 
             for h in ticker_to_holdings[yf_ticker]:
                 results[h["id"]] = {
                     "price": price,
                     "currency": currency,
+                    "price_date": price_date,
                 }
         except Exception:
             # Individual ticker failure — skip, will be reported as failed

--- a/backend/services/snapshots.py
+++ b/backend/services/snapshots.py
@@ -1,0 +1,155 @@
+"""Snapshot service: captures daily portfolio state."""
+
+from __future__ import annotations
+
+import json
+from datetime import date, timezone, datetime
+
+from sqlalchemy.orm import Session
+
+from ..models import (
+    Portfolio,
+    PortfolioSnapshot,
+    SnapshotAllocation,
+    SnapshotHolding,
+)
+from .rebalancer import _to_base
+
+
+def create_snapshot(db: Session, portfolio_id: int) -> PortfolioSnapshot:
+    """Create or update today's snapshot for a portfolio.
+
+    Computes total value, cash value, allocation breakdowns (by asset_type,
+    sector, geography), and per-holding snapshots. If a snapshot already
+    exists for today, it is replaced (upsert).
+    """
+    portfolio = db.get(Portfolio, portfolio_id)
+    if portfolio is None:
+        raise ValueError(f"Portfolio {portfolio_id} not found")
+
+    today = datetime.now(timezone.utc).date()
+
+    # Upsert: delete existing snapshot for today if present
+    existing = (
+        db.query(PortfolioSnapshot)
+        .filter_by(portfolio_id=portfolio_id, snapshot_date=today)
+        .first()
+    )
+    if existing:
+        db.delete(existing)
+        db.flush()
+
+    # Compute values
+    holdings = portfolio.holdings
+    holdings_value = sum(_to_base(h, portfolio) for h in holdings)
+
+    cash_value_base = 0.0
+    for acct in portfolio.accounts:
+        cash = acct.cash_balance
+        cur = acct.currency.upper()
+        base = portfolio.base_currency.upper()
+        if cur == base:
+            cash_value_base += cash
+        elif cur == "EUR":
+            cash_value_base += cash * portfolio.eur_to_base
+        elif cur == "USD":
+            cash_value_base += cash * portfolio.usd_to_base
+        else:
+            cash_value_base += cash
+
+    total_value = holdings_value + cash_value_base
+
+    snapshot = PortfolioSnapshot(
+        portfolio_id=portfolio_id,
+        snapshot_date=today,
+        total_value_base=round(total_value, 2),
+        cash_value_base=round(cash_value_base, 2),
+        eur_to_base=portfolio.eur_to_base,
+        usd_to_base=portfolio.usd_to_base,
+    )
+    db.add(snapshot)
+    db.flush()  # get snapshot.id
+
+    # Allocation breakdowns for all 3 dimensions
+    for dim in ("asset_type", "sector", "geography"):
+        by_cat: dict[str, float] = {}
+        for h in holdings:
+            val = _to_base(h, portfolio)
+            if dim == "asset_type":
+                if h.allocation_breakdown:
+                    breakdown = (
+                        json.loads(h.allocation_breakdown)
+                        if isinstance(h.allocation_breakdown, str)
+                        else h.allocation_breakdown
+                    )
+                    for cat, pct in breakdown.items():
+                        by_cat[cat] = by_cat.get(cat, 0.0) + val * (pct / 100)
+                else:
+                    by_cat[h.asset_type] = by_cat.get(h.asset_type, 0.0) + val
+            elif dim == "sector":
+                key = h.sector or "unclassified"
+                by_cat[key] = by_cat.get(key, 0.0) + val
+            elif dim == "geography":
+                key = h.geography or "unclassified"
+                by_cat[key] = by_cat.get(key, 0.0) + val
+
+        # Add account cash for asset_type dimension
+        if dim == "asset_type" and cash_value_base > 0:
+            by_cat["cash"] = by_cat.get("cash", 0.0) + cash_value_base
+
+        dim_total = sum(by_cat.values())
+        for cat, val in by_cat.items():
+            pct = (val / dim_total * 100) if dim_total > 0 else 0.0
+            db.add(SnapshotAllocation(
+                snapshot_id=snapshot.id,
+                dimension=dim,
+                category=cat,
+                value_base=round(val, 2),
+                pct=round(pct, 2),
+            ))
+
+    # Per-holding snapshots
+    for h in holdings:
+        val = _to_base(h, portfolio)
+        db.add(SnapshotHolding(
+            snapshot_id=snapshot.id,
+            holding_id=h.id,
+            account_id=h.account_id,
+            name=h.name,
+            ticker=h.ticker,
+            asset_type=h.asset_type,
+            quantity=h.quantity,
+            price_per_unit=h.price_per_unit,
+            currency=h.currency,
+            value_base=round(val, 2),
+        ))
+
+    # Cash entries as snapshot holdings
+    for acct in portfolio.accounts:
+        if acct.cash_balance > 0:
+            cur = acct.currency.upper()
+            base = portfolio.base_currency.upper()
+            if cur == base:
+                cash_base = acct.cash_balance
+            elif cur == "EUR":
+                cash_base = acct.cash_balance * portfolio.eur_to_base
+            elif cur == "USD":
+                cash_base = acct.cash_balance * portfolio.usd_to_base
+            else:
+                cash_base = acct.cash_balance
+
+            db.add(SnapshotHolding(
+                snapshot_id=snapshot.id,
+                holding_id=None,
+                account_id=acct.id,
+                name=f"Cash ({acct.name})",
+                ticker=None,
+                asset_type="cash",
+                quantity=acct.cash_balance,
+                price_per_unit=1.0,
+                currency=acct.currency,
+                value_base=round(cash_base, 2),
+            ))
+
+    db.commit()
+    return snapshot

--- a/frontend/app/portfolio/[id]/history/page.tsx
+++ b/frontend/app/portfolio/[id]/history/page.tsx
@@ -1,0 +1,315 @@
+"use client";
+
+import { useEffect, useState, useCallback } from "react";
+import { useParams } from "next/navigation";
+import { toast } from "sonner";
+import type {
+  PortfolioDetail as PDetail,
+  PortfolioHistoryResponse,
+  AllocationHistoryResponse,
+  HoldingHistoryResponse,
+  SnapshotSummary,
+} from "@/lib/types";
+import {
+  getPortfolio,
+  getPortfolioHistory,
+  getAllocationHistory,
+  getHoldingHistory,
+  getSnapshots,
+  createSnapshot,
+} from "@/lib/api";
+import { formatCurrency } from "@/lib/format";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import {
+  Tabs,
+  TabsList,
+  TabsTrigger,
+} from "@/components/ui/tabs";
+import {
+  Select,
+  SelectTrigger,
+  SelectValue,
+  SelectContent,
+  SelectItem,
+} from "@/components/ui/select";
+import { PortfolioNav } from "@/components/portfolio-nav";
+import { StatCard } from "@/components/stat-card";
+import { LineChart } from "@/components/line-chart";
+import { AreaChart } from "@/components/area-chart";
+import { DateRangeSelector, getDateRange } from "@/components/date-range-selector";
+import { Camera } from "lucide-react";
+
+const DIMENSION_LABELS: Record<string, string> = {
+  asset_type: "Asset Type",
+  sector: "Sector",
+  geography: "Geography",
+};
+
+function formatDateLabel(dateStr: string): string {
+  const d = new Date(dateStr + "T00:00:00");
+  return d.toLocaleDateString("en-CA", { month: "short", day: "numeric" });
+}
+
+export default function HistoryPage() {
+  const { id } = useParams<{ id: string }>();
+  const portfolioId = Number(id);
+
+  const [portfolio, setPortfolio] = useState<PDetail | null>(null);
+  const [tab, setTab] = useState<"value" | "allocation" | "holding">("value");
+  const [rangeMonths, setRangeMonths] = useState(0); // 0 = all
+  const [snapshotList, setSnapshotList] = useState<SnapshotSummary[]>([]);
+  const [takingSnapshot, setTakingSnapshot] = useState(false);
+
+  // Value tab
+  const [historyData, setHistoryData] = useState<PortfolioHistoryResponse | null>(null);
+
+  // Allocation tab
+  const [allocDimension, setAllocDimension] = useState("asset_type");
+  const [allocData, setAllocData] = useState<AllocationHistoryResponse | null>(null);
+
+  // Holding tab
+  const [selectedHoldingId, setSelectedHoldingId] = useState<number | null>(null);
+  const [holdingData, setHoldingData] = useState<HoldingHistoryResponse | null>(null);
+
+  const loadPortfolio = useCallback(() => {
+    getPortfolio(portfolioId).then(setPortfolio);
+    getSnapshots(portfolioId, 5).then(setSnapshotList);
+  }, [portfolioId]);
+
+  useEffect(() => { loadPortfolio(); }, [loadPortfolio]);
+
+  // Load data when tab or range changes
+  useEffect(() => {
+    const { from, to } = getDateRange(rangeMonths);
+
+    if (tab === "value") {
+      getPortfolioHistory(portfolioId, from, to).then(setHistoryData);
+    } else if (tab === "allocation") {
+      getAllocationHistory(portfolioId, allocDimension, from, to).then(setAllocData);
+    } else if (tab === "holding" && selectedHoldingId) {
+      getHoldingHistory(portfolioId, selectedHoldingId, from, to).then(setHoldingData);
+    }
+  }, [portfolioId, tab, rangeMonths, allocDimension, selectedHoldingId]);
+
+  // Auto-select first holding
+  useEffect(() => {
+    if (portfolio && portfolio.holdings.length > 0 && selectedHoldingId === null) {
+      setSelectedHoldingId(portfolio.holdings[0].id);
+    }
+  }, [portfolio, selectedHoldingId]);
+
+  const handleTakeSnapshot = async () => {
+    setTakingSnapshot(true);
+    try {
+      await createSnapshot(portfolioId);
+      toast.success("Snapshot created");
+      loadPortfolio();
+      // Refresh current tab data
+      const { from, to } = getDateRange(rangeMonths);
+      if (tab === "value") getPortfolioHistory(portfolioId, from, to).then(setHistoryData);
+      if (tab === "allocation") getAllocationHistory(portfolioId, allocDimension, from, to).then(setAllocData);
+      if (tab === "holding" && selectedHoldingId) getHoldingHistory(portfolioId, selectedHoldingId, from, to).then(setHoldingData);
+    } catch (e: unknown) {
+      toast.error(e instanceof Error ? e.message : "Failed to create snapshot");
+    } finally {
+      setTakingSnapshot(false);
+    }
+  };
+
+  if (!portfolio) {
+    return (
+      <div className="space-y-4">
+        <div className="h-10 w-48 animate-pulse rounded bg-muted" />
+        <div className="h-64 animate-pulse rounded bg-muted" />
+      </div>
+    );
+  }
+
+  const fmt = (n: number) => formatCurrency(n, portfolio.base_currency);
+
+  // Value tab stats
+  const valuePoints = historyData?.data_points || [];
+  const currentValue = valuePoints.length > 0 ? valuePoints[valuePoints.length - 1].total_value_base : 0;
+  const firstValue = valuePoints.length > 0 ? valuePoints[0].total_value_base : 0;
+  const periodChange = currentValue - firstValue;
+  const periodChangePct = firstValue > 0 ? (periodChange / firstValue) * 100 : 0;
+  const periodHigh = valuePoints.length > 0 ? Math.max(...valuePoints.map((p) => p.total_value_base)) : 0;
+  const periodLow = valuePoints.length > 0 ? Math.min(...valuePoints.map((p) => p.total_value_base)) : 0;
+
+  const lastSnapshotDate = snapshotList.length > 0 ? snapshotList[0].snapshot_date : null;
+
+  return (
+    <div>
+      <div className="animate-fade-in-up stagger-1">
+        <PortfolioNav portfolioId={id} portfolioName={portfolio.name} />
+      </div>
+
+      {/* Header row */}
+      <div className="animate-fade-in-up stagger-2 mb-4 flex items-center justify-between">
+        <div className="flex items-center gap-3">
+          <h2 className="text-lg font-semibold">Portfolio History</h2>
+          {lastSnapshotDate && (
+            <span className="text-xs text-muted-foreground">
+              Last snapshot: {lastSnapshotDate}
+            </span>
+          )}
+        </div>
+        <Button size="sm" variant="outline" onClick={handleTakeSnapshot} disabled={takingSnapshot}>
+          <Camera className="mr-1.5 h-3.5 w-3.5" />
+          {takingSnapshot ? "Creating..." : "Take Snapshot"}
+        </Button>
+      </div>
+
+      {/* Tabs */}
+      <div className="animate-fade-in-up stagger-3">
+        <Tabs value={tab} onValueChange={(v) => setTab(v as typeof tab)}>
+          <div className="mb-4 flex items-center justify-between">
+            <TabsList>
+              <TabsTrigger value="value">Portfolio Value</TabsTrigger>
+              <TabsTrigger value="allocation">Allocation Drift</TabsTrigger>
+              <TabsTrigger value="holding">Holding Performance</TabsTrigger>
+            </TabsList>
+            <DateRangeSelector value={rangeMonths} onChange={setRangeMonths} />
+          </div>
+        </Tabs>
+
+        {/* Value Tab */}
+        {tab === "value" && (
+          <div className="space-y-4">
+            {valuePoints.length > 1 && (
+              <div className="grid grid-cols-2 gap-4 lg:grid-cols-4">
+                <StatCard label="Current Value" value={fmt(currentValue)} subtitle={portfolio.base_currency} size="lg" />
+                <StatCard
+                  label="Period Change"
+                  value={`${periodChange >= 0 ? "+" : ""}${fmt(periodChange)}`}
+                  subtitle={`${periodChangePct >= 0 ? "+" : ""}${periodChangePct.toFixed(1)}%`}
+                />
+                <StatCard label="Period High" value={fmt(periodHigh)} />
+                <StatCard label="Period Low" value={fmt(periodLow)} />
+              </div>
+            )}
+            <Card>
+              <CardContent className="pt-6">
+                <LineChart
+                  data={valuePoints.map((p) => ({ label: formatDateLabel(p.date), value: p.total_value_base }))}
+                  currency={portfolio.base_currency}
+                />
+              </CardContent>
+            </Card>
+          </div>
+        )}
+
+        {/* Allocation Tab */}
+        {tab === "allocation" && (
+          <div className="space-y-4">
+            <div className="flex items-center gap-2">
+              <Tabs value={allocDimension} onValueChange={setAllocDimension}>
+                <TabsList>
+                  {Object.entries(DIMENSION_LABELS).map(([key, label]) => (
+                    <TabsTrigger key={key} value={key}>{label}</TabsTrigger>
+                  ))}
+                </TabsList>
+              </Tabs>
+            </div>
+            <Card>
+              <CardContent className="pt-6">
+                <AreaChart
+                  data={(allocData?.data_points || []).map((p) => ({
+                    label: formatDateLabel(p.date),
+                    values: p.values,
+                  }))}
+                  categories={allocData?.categories || []}
+                />
+              </CardContent>
+            </Card>
+          </div>
+        )}
+
+        {/* Holding Tab */}
+        {tab === "holding" && (
+          <div className="space-y-4">
+            <Select
+              value={selectedHoldingId ? String(selectedHoldingId) : ""}
+              onValueChange={(v) => setSelectedHoldingId(Number(v))}
+            >
+              <SelectTrigger className="w-64">
+                <SelectValue placeholder="Select holding" />
+              </SelectTrigger>
+              <SelectContent>
+                {portfolio.holdings.map((h) => (
+                  <SelectItem key={h.id} value={String(h.id)}>
+                    {h.name} {h.ticker ? `(${h.ticker})` : ""}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+
+            {holdingData && holdingData.data_points.length > 0 && (
+              <>
+                <div className="grid grid-cols-2 gap-4 lg:grid-cols-3">
+                  <StatCard
+                    label={holdingData.holding_name}
+                    value={fmt(holdingData.data_points[holdingData.data_points.length - 1].value_base)}
+                    subtitle={holdingData.ticker || undefined}
+                    size="lg"
+                  />
+                  <StatCard
+                    label="Value Change"
+                    value={(() => {
+                      const first = holdingData.data_points[0].value_base;
+                      const last = holdingData.data_points[holdingData.data_points.length - 1].value_base;
+                      const diff = last - first;
+                      return `${diff >= 0 ? "+" : ""}${fmt(diff)}`;
+                    })()}
+                    subtitle={(() => {
+                      const first = holdingData.data_points[0].value_base;
+                      const last = holdingData.data_points[holdingData.data_points.length - 1].value_base;
+                      const pct = first > 0 ? ((last - first) / first) * 100 : 0;
+                      return `${pct >= 0 ? "+" : ""}${pct.toFixed(1)}%`;
+                    })()}
+                  />
+                  <StatCard
+                    label="Price Change"
+                    value={(() => {
+                      const first = holdingData.data_points[0].price_per_unit;
+                      const last = holdingData.data_points[holdingData.data_points.length - 1].price_per_unit;
+                      const diff = last - first;
+                      return `${diff >= 0 ? "+" : ""}${diff.toFixed(2)}`;
+                    })()}
+                    subtitle={(() => {
+                      const first = holdingData.data_points[0].price_per_unit;
+                      const last = holdingData.data_points[holdingData.data_points.length - 1].price_per_unit;
+                      const pct = first > 0 ? ((last - first) / first) * 100 : 0;
+                      return `${pct >= 0 ? "+" : ""}${pct.toFixed(1)}%`;
+                    })()}
+                  />
+                </div>
+                <Card>
+                  <CardContent className="pt-6">
+                    <LineChart
+                      data={holdingData.data_points.map((p) => ({
+                        label: formatDateLabel(p.date),
+                        value: p.value_base,
+                      }))}
+                      currency={portfolio.base_currency}
+                      color="var(--color-blue)"
+                    />
+                  </CardContent>
+                </Card>
+              </>
+            )}
+
+            {holdingData && holdingData.data_points.length === 0 && (
+              <Card>
+                <CardContent className="flex items-center justify-center py-12 text-sm text-muted-foreground">
+                  No history data for this holding. Take a snapshot first.
+                </CardContent>
+              </Card>
+            )}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/app/portfolio/[id]/page.tsx
+++ b/frontend/app/portfolio/[id]/page.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useState } from "react";
 import { useParams } from "next/navigation";
-import { Plus, MoreHorizontal, Pencil, Trash2, PackageOpen, ChevronDown } from "lucide-react";
+import { Plus, MoreHorizontal, Pencil, Trash2, PackageOpen, ChevronDown, Camera } from "lucide-react";
 import { toast } from "sonner";
 import type { PortfolioDetail as PDetail, HoldingInput } from "@/lib/types";
 import {
@@ -12,7 +12,10 @@ import {
   updateHolding,
   updatePortfolio,
   syncExchangeRates,
+  getSnapshots,
+  createSnapshot,
 } from "@/lib/api";
+import type { SnapshotSummary } from "@/lib/types";
 import { formatCurrency } from "@/lib/format";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -103,6 +106,8 @@ export default function PortfolioDetail() {
   const [filterAccountId, setFilterAccountId] = useState<string>("all");
   const [deleteId, setDeleteId] = useState<number | null>(null);
   const [fetchingRates, setFetchingRates] = useState(false);
+  const [lastSnapshot, setLastSnapshot] = useState<SnapshotSummary | null>(null);
+  const [takingSnapshot, setTakingSnapshot] = useState(false);
 
   const load = () => {
     if (!id) return;
@@ -114,6 +119,22 @@ export default function PortfolioDetail() {
         setForm((f) => ({ ...f, account_id: p.accounts[0].id }));
       }
     });
+    getSnapshots(Number(id), 1).then((snaps) => {
+      setLastSnapshot(snaps.length > 0 ? snaps[0] : null);
+    });
+  };
+
+  const handleTakeSnapshot = async () => {
+    setTakingSnapshot(true);
+    try {
+      await createSnapshot(Number(id));
+      toast.success("Snapshot created");
+      load();
+    } catch (e: unknown) {
+      toast.error(e instanceof Error ? e.message : "Failed to create snapshot");
+    } finally {
+      setTakingSnapshot(false);
+    }
   };
 
   useEffect(() => {
@@ -246,6 +267,19 @@ export default function PortfolioDetail() {
       {/* Sub-navigation with breadcrumb */}
       <div className="animate-fade-in-up stagger-1">
         <PortfolioNav portfolioId={id} portfolioName={portfolio.name} />
+      </div>
+
+      {/* Snapshot indicator */}
+      <div className="animate-fade-in-up stagger-2 mb-2 flex items-center justify-end gap-2">
+        {lastSnapshot && (
+          <span className="text-xs text-muted-foreground">
+            Last snapshot: {lastSnapshot.snapshot_date}
+          </span>
+        )}
+        <Button size="sm" variant="ghost" onClick={handleTakeSnapshot} disabled={takingSnapshot} className="h-7 text-xs">
+          <Camera className="mr-1 h-3 w-3" />
+          {takingSnapshot ? "Creating..." : "Snapshot"}
+        </Button>
       </div>
 
       {/* Stat Cards Grid */}

--- a/frontend/components/area-chart.tsx
+++ b/frontend/components/area-chart.tsx
@@ -1,0 +1,185 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+// Same palette as donut-chart.tsx
+const PALETTE_STROKE = [
+  "var(--color-gold)",
+  "var(--color-blue)",
+  "var(--color-green)",
+  "var(--color-orange)",
+  "var(--color-purple)",
+  "var(--color-yellow)",
+  "var(--color-red)",
+  "hsl(180 40% 55%)",
+  "hsl(320 35% 55%)",
+  "hsl(60 45% 55%)",
+];
+
+const PALETTE_DOT = [
+  "bg-gold",
+  "bg-blue",
+  "bg-green",
+  "bg-orange",
+  "bg-purple",
+  "bg-yellow",
+  "bg-red",
+  "bg-[hsl(180_40%_55%)]",
+  "bg-[hsl(320_35%_55%)]",
+  "bg-[hsl(60_45%_55%)]",
+];
+
+interface AreaDataPoint {
+  label: string;
+  values: Record<string, number>; // category -> percentage
+}
+
+interface AreaChartProps {
+  data: AreaDataPoint[];
+  categories: string[];
+  height?: number;
+}
+
+const PADDING = { top: 12, right: 16, bottom: 32, left: 40 };
+
+export function AreaChart({ data, categories, height = 260 }: AreaChartProps) {
+  const [mounted, setMounted] = useState(false);
+
+  useEffect(() => {
+    const timer = requestAnimationFrame(() => setMounted(true));
+    return () => cancelAnimationFrame(timer);
+  }, []);
+
+  if (data.length === 0) {
+    return (
+      <div className="flex items-center justify-center text-sm text-muted-foreground" style={{ height }}>
+        No data available
+      </div>
+    );
+  }
+
+  const width = 600;
+  const chartW = width - PADDING.left - PADDING.right;
+  const chartH = height - PADDING.top - PADDING.bottom;
+
+  const toX = (i: number) => PADDING.left + (i / Math.max(data.length - 1, 1)) * chartW;
+  const toY = (pct: number) => PADDING.top + (1 - pct / 100) * chartH;
+
+  // Build stacked areas — categories stacked bottom to top
+  const stackedPaths: { category: string; path: string; color: string }[] = [];
+
+  // Compute cumulative values
+  for (let ci = 0; ci < categories.length; ci++) {
+    const cat = categories[ci];
+    const color = PALETTE_STROKE[ci % PALETTE_STROKE.length];
+
+    // For each data point, cumulative = sum of categories[0..ci]
+    const topPoints = data.map((d, i) => {
+      let cum = 0;
+      for (let j = 0; j <= ci; j++) {
+        cum += d.values[categories[j]] || 0;
+      }
+      return { x: toX(i), y: toY(cum) };
+    });
+
+    // Bottom edge = cumulative of categories[0..ci-1]
+    const bottomPoints = data.map((d, i) => {
+      let cum = 0;
+      for (let j = 0; j < ci; j++) {
+        cum += d.values[categories[j]] || 0;
+      }
+      return { x: toX(i), y: toY(cum) };
+    });
+
+    // Build path: top line forward, bottom line backward
+    const topLine = topPoints.map((p, i) => `${i === 0 ? "M" : "L"} ${p.x.toFixed(1)} ${p.y.toFixed(1)}`).join(" ");
+    const bottomLine = [...bottomPoints].reverse().map((p) => `L ${p.x.toFixed(1)} ${p.y.toFixed(1)}`).join(" ");
+    const path = `${topLine} ${bottomLine} Z`;
+
+    stackedPaths.push({ category: cat, path, color });
+  }
+
+  // Y-axis ticks
+  const yTicks = [0, 25, 50, 75, 100];
+
+  // X-axis labels
+  const labelStep = Math.max(1, Math.floor(data.length / 5));
+  const xLabels = data.filter((_, i) => i % labelStep === 0 || i === data.length - 1);
+
+  return (
+    <div>
+      <svg
+        viewBox={`0 0 ${width} ${height}`}
+        className="w-full"
+        style={{ maxHeight: height }}
+      >
+        {/* Grid */}
+        {yTicks.map((tick) => (
+          <line
+            key={tick}
+            x1={PADDING.left}
+            x2={width - PADDING.right}
+            y1={toY(tick)}
+            y2={toY(tick)}
+            stroke="var(--color-border)"
+            strokeWidth={0.5}
+          />
+        ))}
+
+        {/* Y labels */}
+        {yTicks.map((tick) => (
+          <text
+            key={tick}
+            x={PADDING.left - 6}
+            y={toY(tick) + 4}
+            textAnchor="end"
+            className="fill-muted-foreground"
+            fontSize={10}
+          >
+            {tick}%
+          </text>
+        ))}
+
+        {/* X labels */}
+        {xLabels.map((d) => {
+          const i = data.indexOf(d);
+          return (
+            <text
+              key={d.label}
+              x={toX(i)}
+              y={height - 6}
+              textAnchor="middle"
+              className="fill-muted-foreground"
+              fontSize={10}
+            >
+              {d.label}
+            </text>
+          );
+        })}
+
+        {/* Stacked areas (render in reverse so first category is on top visually) */}
+        {[...stackedPaths].reverse().map((sp) => (
+          <path
+            key={sp.category}
+            d={mounted ? sp.path : ""}
+            fill={sp.color}
+            opacity={0.35}
+            stroke={sp.color}
+            strokeWidth={1}
+            className="transition-all duration-700 ease-out"
+          />
+        ))}
+      </svg>
+
+      {/* Legend */}
+      <div className="mt-3 flex flex-wrap gap-x-4 gap-y-1.5 px-2">
+        {categories.map((cat, i) => (
+          <div key={cat} className="flex items-center gap-1.5 text-xs">
+            <span className={`inline-block h-2.5 w-2.5 flex-shrink-0 rounded-full ${PALETTE_DOT[i % PALETTE_DOT.length]}`} />
+            <span className="capitalize text-muted-foreground">{cat}</span>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/frontend/components/date-range-selector.tsx
+++ b/frontend/components/date-range-selector.tsx
@@ -1,0 +1,45 @@
+"use client";
+
+import { Button } from "@/components/ui/button";
+
+const PRESETS = [
+  { label: "1M", months: 1 },
+  { label: "3M", months: 3 },
+  { label: "6M", months: 6 },
+  { label: "1Y", months: 12 },
+  { label: "All", months: 0 },
+] as const;
+
+interface DateRangeSelectorProps {
+  value: number; // months, 0 = all
+  onChange: (months: number) => void;
+}
+
+export function DateRangeSelector({ value, onChange }: DateRangeSelectorProps) {
+  return (
+    <div className="flex gap-1">
+      {PRESETS.map((p) => (
+        <Button
+          key={p.label}
+          variant={value === p.months ? "default" : "ghost"}
+          size="sm"
+          className="h-7 px-2.5 text-xs"
+          onClick={() => onChange(p.months)}
+        >
+          {p.label}
+        </Button>
+      ))}
+    </div>
+  );
+}
+
+export function getDateRange(months: number): { from?: string; to?: string } {
+  if (months === 0) return {};
+  const to = new Date();
+  const from = new Date();
+  from.setMonth(from.getMonth() - months);
+  return {
+    from: from.toISOString().split("T")[0],
+    to: to.toISOString().split("T")[0],
+  };
+}

--- a/frontend/components/line-chart.tsx
+++ b/frontend/components/line-chart.tsx
@@ -1,0 +1,154 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { formatCurrency } from "@/lib/format";
+
+interface DataPoint {
+  label: string;
+  value: number;
+}
+
+interface LineChartProps {
+  data: DataPoint[];
+  currency?: string;
+  color?: string;
+  height?: number;
+  showArea?: boolean;
+}
+
+const PADDING = { top: 20, right: 16, bottom: 32, left: 72 };
+
+export function LineChart({
+  data,
+  currency = "CAD",
+  color = "var(--color-gold)",
+  height = 260,
+  showArea = true,
+}: LineChartProps) {
+  const [mounted, setMounted] = useState(false);
+
+  useEffect(() => {
+    const timer = requestAnimationFrame(() => setMounted(true));
+    return () => cancelAnimationFrame(timer);
+  }, []);
+
+  if (data.length === 0) {
+    return (
+      <div className="flex items-center justify-center text-sm text-muted-foreground" style={{ height }}>
+        No data available
+      </div>
+    );
+  }
+
+  const width = 600;
+  const chartW = width - PADDING.left - PADDING.right;
+  const chartH = height - PADDING.top - PADDING.bottom;
+
+  const values = data.map((d) => d.value);
+  const minVal = Math.min(...values);
+  const maxVal = Math.max(...values);
+  const range = maxVal - minVal || 1;
+  const yPad = range * 0.08;
+  const yMin = minVal - yPad;
+  const yMax = maxVal + yPad;
+
+  const toX = (i: number) => PADDING.left + (i / Math.max(data.length - 1, 1)) * chartW;
+  const toY = (v: number) => PADDING.top + (1 - (v - yMin) / (yMax - yMin)) * chartH;
+
+  const linePath = data
+    .map((d, i) => `${i === 0 ? "M" : "L"} ${toX(i).toFixed(1)} ${toY(d.value).toFixed(1)}`)
+    .join(" ");
+
+  const areaPath = `${linePath} L ${toX(data.length - 1).toFixed(1)} ${(PADDING.top + chartH).toFixed(1)} L ${PADDING.left.toFixed(1)} ${(PADDING.top + chartH).toFixed(1)} Z`;
+
+  // Y-axis ticks (5 ticks)
+  const yTicks = Array.from({ length: 5 }, (_, i) => yMin + ((yMax - yMin) * i) / 4);
+
+  // X-axis labels (show ~5 labels)
+  const labelStep = Math.max(1, Math.floor(data.length / 5));
+  const xLabels = data.filter((_, i) => i % labelStep === 0 || i === data.length - 1);
+
+  return (
+    <svg
+      viewBox={`0 0 ${width} ${height}`}
+      className="w-full"
+      style={{ maxHeight: height }}
+    >
+      {/* Grid lines */}
+      {yTicks.map((tick) => (
+        <line
+          key={tick}
+          x1={PADDING.left}
+          x2={width - PADDING.right}
+          y1={toY(tick)}
+          y2={toY(tick)}
+          stroke="var(--color-border)"
+          strokeWidth={0.5}
+        />
+      ))}
+
+      {/* Y-axis labels */}
+      {yTicks.map((tick) => (
+        <text
+          key={tick}
+          x={PADDING.left - 8}
+          y={toY(tick) + 4}
+          textAnchor="end"
+          className="fill-muted-foreground"
+          fontSize={10}
+        >
+          {formatCurrency(tick, currency)}
+        </text>
+      ))}
+
+      {/* X-axis labels */}
+      {xLabels.map((d) => {
+        const i = data.indexOf(d);
+        return (
+          <text
+            key={d.label}
+            x={toX(i)}
+            y={height - 6}
+            textAnchor="middle"
+            className="fill-muted-foreground"
+            fontSize={10}
+          >
+            {d.label}
+          </text>
+        );
+      })}
+
+      {/* Area fill */}
+      {showArea && (
+        <path
+          d={mounted ? areaPath : ""}
+          fill={color}
+          opacity={0.08}
+          className="transition-all duration-700 ease-out"
+        />
+      )}
+
+      {/* Line */}
+      <path
+        d={mounted ? linePath : ""}
+        fill="none"
+        stroke={color}
+        strokeWidth={2}
+        strokeLinejoin="round"
+        strokeLinecap="round"
+        className="transition-all duration-700 ease-out"
+      />
+
+      {/* End dot */}
+      {data.length > 0 && mounted && (
+        <circle
+          cx={toX(data.length - 1)}
+          cy={toY(data[data.length - 1].value)}
+          r={3.5}
+          fill={color}
+          className="transition-all duration-700 ease-out"
+        />
+      )}
+    </svg>
+  );
+}

--- a/frontend/components/portfolio-nav.tsx
+++ b/frontend/components/portfolio-nav.tsx
@@ -2,7 +2,7 @@
 
 import Link from "next/link";
 import { usePathname } from "next/navigation";
-import { BarChart3, Wallet, Scale, ChevronRight } from "lucide-react";
+import { BarChart3, Wallet, Scale, LineChart, ChevronRight } from "lucide-react";
 import { Separator } from "@/components/ui/separator";
 
 interface PortfolioNavProps {
@@ -14,6 +14,7 @@ const tabs = [
   { label: "Holdings", href: "", icon: BarChart3 },
   { label: "Accounts", href: "/accounts", icon: Wallet },
   { label: "Rebalance", href: "/rebalance", icon: Scale },
+  { label: "History", href: "/history", icon: LineChart },
 ] as const;
 
 export function PortfolioNav({ portfolioId, portfolioName }: PortfolioNavProps) {

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -15,6 +15,10 @@ import type {
   Account,
   PriceSyncResult,
   ExchangeRateSyncResult,
+  SnapshotSummary,
+  PortfolioHistoryResponse,
+  AllocationHistoryResponse,
+  HoldingHistoryResponse,
 } from "./types";
 
 const BASE = "/api";
@@ -106,6 +110,37 @@ export const syncExchangeRates = (portfolioId: number) =>
   request<ExchangeRateSyncResult>(`/sync/${portfolioId}/exchange-rates`, {
     method: "POST",
   });
+
+// Snapshots
+export const createSnapshot = (portfolioId: number) =>
+  request<SnapshotSummary>(`/snapshots/${portfolioId}`, { method: "POST" });
+
+export const getSnapshots = (portfolioId: number, limit?: number) =>
+  request<SnapshotSummary[]>(`/snapshots/${portfolioId}${limit ? `?limit=${limit}` : ""}`);
+
+export const getPortfolioHistory = (portfolioId: number, from?: string, to?: string) => {
+  const params = new URLSearchParams();
+  if (from) params.set("from", from);
+  if (to) params.set("to", to);
+  const qs = params.toString();
+  return request<PortfolioHistoryResponse>(`/snapshots/${portfolioId}/history${qs ? `?${qs}` : ""}`);
+};
+
+export const getAllocationHistory = (portfolioId: number, dimension: string, from?: string, to?: string) => {
+  const params = new URLSearchParams();
+  params.set("dimension", dimension);
+  if (from) params.set("from", from);
+  if (to) params.set("to", to);
+  return request<AllocationHistoryResponse>(`/snapshots/${portfolioId}/allocations?${params.toString()}`);
+};
+
+export const getHoldingHistory = (portfolioId: number, holdingId: number, from?: string, to?: string) => {
+  const params = new URLSearchParams();
+  if (from) params.set("from", from);
+  if (to) params.set("to", to);
+  const qs = params.toString();
+  return request<HoldingHistoryResponse>(`/snapshots/${portfolioId}/holdings/${holdingId}${qs ? `?${qs}` : ""}`);
+};
 
 // Questrade
 export const questradeAuth = (refreshToken: string) =>

--- a/frontend/lib/types.ts
+++ b/frontend/lib/types.ts
@@ -144,6 +144,7 @@ export interface PriceSyncDetail {
   old_price: number;
   new_price: number;
   currency: string;
+  price_date: string | null;
 }
 
 export interface PriceSyncResult {
@@ -158,4 +159,47 @@ export interface ExchangeRateSyncResult {
   usd_to_base: number;
   source: string;
   date: string;
+}
+
+// Snapshots
+export interface SnapshotSummary {
+  id: number;
+  snapshot_date: string;
+  total_value_base: number;
+  created_at: string;
+}
+
+export interface PortfolioHistoryPoint {
+  date: string;
+  total_value_base: number;
+  cash_value_base: number;
+}
+
+export interface PortfolioHistoryResponse {
+  base_currency: string;
+  data_points: PortfolioHistoryPoint[];
+}
+
+export interface AllocationHistoryPoint {
+  date: string;
+  values: Record<string, number>;
+}
+
+export interface AllocationHistoryResponse {
+  dimension: string;
+  categories: string[];
+  data_points: AllocationHistoryPoint[];
+}
+
+export interface HoldingHistoryPoint {
+  date: string;
+  quantity: number;
+  price_per_unit: number;
+  value_base: number;
+}
+
+export interface HoldingHistoryResponse {
+  holding_name: string;
+  ticker: string | null;
+  data_points: HoldingHistoryPoint[];
 }


### PR DESCRIPTION
## Summary
- **Daily portfolio snapshots** — capture portfolio value, allocation percentages, and per-holding state each day (auto-created after price sync, or manually)
- **Portfolio value chart** — line chart showing total portfolio value over time with period stats (change, high, low)
- **Allocation drift chart** — stacked area chart showing how allocations shift over time across asset type, sector, and geography dimensions
- **Holding performance chart** — individual holding value and price tracking over time
- **Date range filtering** — quick presets (1M, 3M, 6M, 1Y, All) for all history views

## New models
- `PortfolioSnapshot` — daily aggregate (total value, cash, exchange rates)
- `SnapshotAllocation` — allocation percentages per dimension/category per snapshot
- `SnapshotHolding` — point-in-time holding capture (preserves data even if holding deleted)

## New endpoints
- `POST /api/snapshots/{id}` — create today's snapshot
- `GET /api/snapshots/{id}` — list recent snapshots
- `GET /api/snapshots/{id}/history` — portfolio value over time
- `GET /api/snapshots/{id}/allocations` — allocation drift over time
- `GET /api/snapshots/{id}/holdings/{holdingId}` — holding performance
- `DELETE /api/snapshots/{id}/history` — cleanup old snapshots

## Frontend
- New History page at `/portfolio/[id]/history` with three tabs
- Custom SVG LineChart and AreaChart components
- DateRangeSelector component
- Snapshot button on portfolio detail page

## Base branch
This branch is built on top of `claude/integrate-external-apis-CG3bA` — price sync auto-triggers snapshot creation.

## Test plan
- [ ] Backend tests pass
- [ ] Frontend builds without errors
- [ ] Create snapshot via API, verify it appears in snapshot list
- [ ] Verify history, allocation, and holding endpoints return correct data
- [ ] History page loads with all three tabs functional